### PR TITLE
Handle protocols in URL for smithery server URL

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -9,22 +9,38 @@ import { createSmitheryUrl } from "./config.js"
  * @returns Transport
  */
 export function createTransport(smitheryServerUrl: string, config?: object) {
-	// Check if HTTP/HTTPS protocol was provided and warn user
-	if (smitheryServerUrl.match(/^https?:\/\//)) {
-		console.warn(
-			'Warning: HTTP/HTTPS protocol detected in smitheryServerUrl. ' +
-			'Converting to WebSocket protocol. For better compatibility, ' +
-			'consider providing the URL without a protocol.'
-		)
+	let url: URL;
+	try {
+		// First try to parse as-is
+		url = new URL(smitheryServerUrl);
+		
+		// For WebSocket connections, only ws: and wss: are valid
+		if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+			// Special case: automatically convert http(s) to ws(s)
+			if (url.protocol === 'http:' || url.protocol === 'https:') {
+				console.warn(
+					'Warning: HTTP/HTTPS protocol detected in smitheryServerUrl. ' +
+					'Converting to WebSocket protocol. For better compatibility, ' +
+					'consider providing the URL without a protocol.'
+				);
+				url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+			} else {
+				throw new Error(
+					`Protocol ${url.protocol} is not supported for WebSocket connections. ` +
+					'Please use ws:// or wss:// (or provide URL without protocol)'
+				);
+			}
+		}
+	} catch (error) {
+		// If initial parsing failed, try with default ws:// protocol
+		try {
+			url = new URL(`ws://${smitheryServerUrl}`);
+		} catch {
+			throw new Error(`Invalid URL provided: ${smitheryServerUrl}`);
+		}
 	}
 
-	// First strip any existing protocol
-	const cleanUrl = smitheryServerUrl.replace(/^(https?|wss?):\/\//, '')
-	
-	// Then add ws:// or wss:// based on whether the original was secure
-	const wsUrl = smitheryServerUrl.startsWith('https') ? `wss://${cleanUrl}` : `ws://${cleanUrl}`
-	
 	return new WebSocketClientTransport(
-		createSmitheryUrl(`${wsUrl}/ws`, config),
-	)
+		createSmitheryUrl(`${url.toString()}/ws`, config),
+	);
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -14,20 +14,20 @@ export function createTransport(smitheryServerUrl: string, config?: object) {
 		// First try to parse as-is
 		url = new URL(smitheryServerUrl);
 		
-		// For WebSocket connections, only ws: and wss: are valid
-		if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+		// For WebSocket connections, ws:, wss:, and ws+unix: are valid
+		if (url.protocol !== 'ws:' && url.protocol !== 'wss:' && url.protocol !== 'ws+unix:') {
 			// Special case: automatically convert http(s) to ws(s)
 			if (url.protocol === 'http:' || url.protocol === 'https:') {
 				console.warn(
 					'Warning: HTTP/HTTPS protocol detected in smitheryServerUrl. ' +
 					'Converting to WebSocket protocol. For better compatibility, ' +
-					'consider providing the URL without a protocol.'
+					'consider providing the URL without protocol.'
 				);
 				url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
 			} else {
 				throw new Error(
 					`Protocol ${url.protocol} is not supported for WebSocket connections. ` +
-					'Please use ws:// or wss:// (or provide URL without protocol)'
+					'Please use ws://, wss://, ws+unix:// (or provide URL without protocol)'
 				);
 			}
 		}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -9,7 +9,22 @@ import { createSmitheryUrl } from "./config.js"
  * @returns Transport
  */
 export function createTransport(smitheryServerUrl: string, config?: object) {
+	// Check if HTTP/HTTPS protocol was provided and warn user
+	if (smitheryServerUrl.match(/^https?:\/\//)) {
+		console.warn(
+			'Warning: HTTP/HTTPS protocol detected in smitheryServerUrl. ' +
+			'Converting to WebSocket protocol. For better compatibility, ' +
+			'consider providing the URL without a protocol.'
+		)
+	}
+
+	// First strip any existing protocol
+	const cleanUrl = smitheryServerUrl.replace(/^(https?|wss?):\/\//, '')
+	
+	// Then add ws:// or wss:// based on whether the original was secure
+	const wsUrl = smitheryServerUrl.startsWith('https') ? `wss://${cleanUrl}` : `ws://${cleanUrl}`
+	
 	return new WebSocketClientTransport(
-		createSmitheryUrl(`${smitheryServerUrl}/ws`, config),
+		createSmitheryUrl(`${wsUrl}/ws`, config),
 	)
 }


### PR DESCRIPTION
• Clearer error messages for unsupported protocols
• Maintains automatic HTTP(S) → WS(S) protocol conversion with warning
• Falls back to ws:// for protocol-less URLs